### PR TITLE
COMP: Take out ITKV3_COMPATIBILITY REQUIREMENT

### DIFF
--- a/Applications/dwiAtlas/dwiAtlas.cxx
+++ b/Applications/dwiAtlas/dwiAtlas.cxx
@@ -56,7 +56,6 @@
 #include <itkBinaryThresholdImageFilter.h>
 
 #include <itkNthElementImageAdaptor.h>
-#include <itkOtsuThresholdImageCalculator.h>
 
 #include "itkVectorMaskNegatedImageFilter.h"
 #include "itkVectorMaskImageFilter.h"

--- a/DTIProcess.cmake
+++ b/DTIProcess.cmake
@@ -53,7 +53,6 @@ set( LIST_ITK_COMPONENTS
   ITKRegistrationCommon
   ITKOptimizersv4
   ITKConnectedComponents
-  ITKV3Compatibility
   ITKMathematicalMorphology
   ITKBinaryMathematicalMorphology
   ITKRegionGrowing
@@ -109,9 +108,6 @@ include(${ITK_USE_FILE})
 # have to save library list because it gets clobbered by GenerateCLP, which
 # calls find_package(ITK) every time it's invoked.
 set(DTIProcess_ITK_LIBRARIES ${ITK_LIBRARIES})
-if( NOT DEFINED ITKV3_COMPATIBILITY OR NOT ${ITKV3_COMPATIBILITY}  )
-  message( WARNING "Choose ITKv4 compiled with ITKV3_COMPATIBILITY set to ON (or GenerateCLP compiled against such an ITK version). If not, you may have compilation errors" )
-endif()
 
 
 

--- a/Library/itkTensorLinearInterpolateImageFunction.h
+++ b/Library/itkTensorLinearInterpolateImageFunction.h
@@ -117,7 +117,7 @@ private:
 #include "Templates/itkTensorLinearInterpolateImageFunction+-.h"
 #endif
 
-#if ITK_TEMPLATE_TXX
+#ifndef ITK_MANUAL_INSTANTIATION
 #include "itkTensorLinearInterpolateImageFunction.txx"
 #endif
 

--- a/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
+++ b/Testing/itkDifferenceDiffusionTensor3DImageFilter.h
@@ -151,7 +151,7 @@ private:
 # include "itkTemplates/DifferenceDiffusionTensor3DImageFilter+-.h"
 #endif
 
-#if ITK_TEMPLATE_TXX
+#ifndef ITK_MANUAL_INSTANTIATION
 # include "itkDifferenceDiffusionTensor3DImageFilter.txx"
 #endif
 


### PR DESCRIPTION
It turns out only small changes need to be made to build DTIProcess without ITKV3_COMPATIBILITY.

This patch contains the necessary changes.
