### PR TITLE
Correct tensor estimation

### DIFF
--- a/Applications/dtiestim.cxx
+++ b/Applications/dtiestim.cxx
@@ -58,6 +58,11 @@
 #include "itkDiffusionTensor3DReconstructionLinearImageFilter.h"
 #include "itkTensorRotateImageFilter.h"
 
+// tensor correction headers
+#include "itkDiffusionTensor3DZeroCorrection.h"
+#include "itkDiffusionTensor3DAbsCorrection.h"
+#include "itkDiffusionTensor3DNearestCorrection.h"
+
 #include <vnl/algo/vnl_svd.h>
 
 #include "dtitypes.h"
@@ -763,6 +768,32 @@ int main(int argc, char* argv[])
     {
     std::cerr << "Invalid estimation method"  << std::endl;
     return EXIT_FAILURE;
+    }
+
+  // Tensors Corrections
+  if( !correction.compare( "zero" ) )
+    {
+    typedef itk::DiffusionTensor3DZeroCorrectionFilter<TensorImageType, TensorImageType> ZeroCorrection;
+    ZeroCorrection::Pointer zeroFilter = ZeroCorrection::New();
+    zeroFilter->SetInput( tensors );
+    zeroFilter->Update();
+    tensors = zeroFilter->GetOutput();
+    }
+  else if( !correction.compare( "abs" ) )
+    {
+    typedef itk::DiffusionTensor3DAbsCorrectionFilter<TensorImageType, TensorImageType> AbsCorrection;
+    AbsCorrection::Pointer absFilter = AbsCorrection::New();
+    absFilter->SetInput( tensors );
+    absFilter->Update();
+    tensors = absFilter->GetOutput();
+    }
+  else if( !correction.compare( "nearest" ) )
+    {
+    typedef itk::DiffusionTensor3DNearestCorrectionFilter<TensorImageType, TensorImageType> NearestCorrection;
+    NearestCorrection::Pointer nearestFilter = NearestCorrection::New();
+    nearestFilter->SetInput( tensors );
+    nearestFilter->Update();
+    tensors = nearestFilter->GetOutput();
     }
 
   // wp = D*x

--- a/Applications/dtiestim.xml
+++ b/Applications/dtiestim.xml
@@ -67,7 +67,7 @@
       <description>Brain mask.  Image where for every voxel == 0 the tensors are not estimated. Be aware that in addition a threshold based masking will be performed by default. If such an additional threshold masking is NOT desired, then use option -t 0.</description>
       <channel>input</channel>
       <default></default>
-    </image> 
+    </image>
     <image>
       <name>badRegionMask</name>
       <longflag>--bad_region_mask</longflag>
@@ -80,6 +80,17 @@
   </parameters>
   <parameters advanced="true">
     <label>Options</label>
+    <string-enumeration>
+      <name>correction</name>
+      <longflag>--correction</longflag>
+      <description>Correct the tensors if computed tensor is not semi-definite positive.</description>
+      <label>Tensors Correction</label>
+      <element>none</element>
+      <element>zero</element>
+      <element>abs</element>
+      <element>nearest</element>
+      <default>none</default>
+    </string-enumeration>
     <string-enumeration>
       <name>method</name>
       <label>Method</label>

--- a/Applications/dtiprocess.cxx
+++ b/Applications/dtiprocess.cxx
@@ -34,6 +34,11 @@
 #include "imageio.h"
 #include "deformationfieldio.h"
 
+// tensor correction headers
+#include "itkDiffusionTensor3DZeroCorrection.h"
+#include "itkDiffusionTensor3DAbsCorrection.h"
+#include "itkDiffusionTensor3DNearestCorrection.h"
+
 #include "dtiprocessCLP.h"
 
 // Bad global variables.  TODO: remove these
@@ -136,6 +141,33 @@ int main(int argc, char* argv[])
     }
 
   TensorImageType::Pointer tensors = dtireader->GetOutput();
+
+  // Tensors Corrections
+  if( !correction.compare( "zero" ) )
+    {
+    typedef itk::DiffusionTensor3DZeroCorrectionFilter<TensorImageType, TensorImageType> ZeroCorrection;
+    ZeroCorrection::Pointer zeroFilter = ZeroCorrection::New();
+    zeroFilter->SetInput( tensors );
+    zeroFilter->Update();
+    tensors = zeroFilter->GetOutput();
+    }
+  else if( !correction.compare( "abs" ) )
+    {
+    typedef itk::DiffusionTensor3DAbsCorrectionFilter<TensorImageType, TensorImageType> AbsCorrection;
+    AbsCorrection::Pointer absFilter = AbsCorrection::New();
+    absFilter->SetInput( tensors );
+    absFilter->Update();
+    tensors = absFilter->GetOutput();
+    }
+  else if( !correction.compare( "nearest" ) )
+    {
+    typedef itk::DiffusionTensor3DNearestCorrectionFilter<TensorImageType, TensorImageType> NearestCorrection;
+    NearestCorrection::Pointer nearestFilter = NearestCorrection::New();
+    nearestFilter->SetInput( tensors );
+    nearestFilter->Update();
+    tensors = nearestFilter->GetOutput();
+    }
+
   //  if(vm.count("mask"))
   if( mask != "" )
     {

--- a/Applications/dtiprocess.xml
+++ b/Applications/dtiprocess.xml
@@ -232,6 +232,17 @@
   </parameters>
   <parameters advanced="true">
     <label>Options</label>
+    <string-enumeration>
+      <name>correction</name>
+      <longflag>--correction</longflag>
+      <description>Correct the tensors if computed tensor is not semi-definite positive.</description>
+      <label>Tensors Correction</label>
+      <element>zero</element>
+      <element>none</element>
+      <element>abs</element>
+      <element>nearest</element>
+      <default>none</default>
+    </string-enumeration>
     <boolean>
       <name>scalarFloat</name>
       <longflag>--scalar_float</longflag>

--- a/Library/define.h
+++ b/Library/define.h
@@ -1,0 +1,7 @@
+#ifndef define_h
+#define define_h
+
+#define LOGNEG (-23) // exp(-23) ~= 1e-10
+#define ZERO (1e-10)
+
+#endif

--- a/Library/itkDiffusionTensor3DAbsCorrection.h
+++ b/Library/itkDiffusionTensor3DAbsCorrection.h
@@ -1,0 +1,145 @@
+/*=========================================================================
+
+  Program:   Diffusion Applications
+  Module:    $HeadURL: http://svn.slicer.org/Slicer3/trunk/Applications/CLI/DiffusionApplications/ResampleDTI/itkDiffusionTensor3DAbsCorrection.h $
+  Language:  C++
+  Date:      $Date: 2008-11-25 14:23:08 -0500 (Tue, 25 Nov 2008) $
+  Version:   $Revision: 7976 $
+
+  Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
+
+==========================================================================*/
+#ifndef __itkDiffusionTensor3DAbsCorrectionFilter_h
+#define __itkDiffusionTensor3DAbsCorrectionFilter_h
+
+#include "itkUnaryFunctorImageFilter.h"
+#include "vnl/vnl_math.h"
+#include <itkMatrix.h>
+#include "itkDiffusionTensor3DExtended.h"
+
+namespace itk
+{
+
+/** \class DiffusionTensor3DAbsCorrectionFilter
+ * \brief Computes pixel-wise the absolute value of the diffusion tensor eigenvalues.
+ *
+ * This filter is templated over the pixel type of the input image
+ * and the pixel type of the output image.
+ *
+ * The filter will walk over all the pixels in the input image, and for
+ * each one of them it will do the following:
+ *
+ * - cast the pixel value to \c DiffusionTensor3DExtended<double>,
+ * - Compute the eigenvalues and the eigenvectors
+ * - Set eigenvalues to their absolute value
+ * - store the casted value into the output image.
+ *
+ * The filter expect both images to have the same dimension (e.g. both 2D,
+ * or both 3D, or both ND).
+ * The filter needs DiffusionTensor3D images to work
+ *
+ */
+namespace Functor
+{
+
+template <class TInput, class TOutput>
+class DiffusionTensor3DAbs
+{
+public:
+  DiffusionTensor3DAbs()
+  {
+  }
+
+  ~DiffusionTensor3DAbs()
+  {
+  }
+
+  bool operator!=( const DiffusionTensor3DAbs & other ) const
+  {
+    return *this != other;
+  }
+
+  bool operator==( const DiffusionTensor3DAbs & other ) const
+  {
+    return !( *this != other );
+  }
+
+  inline DiffusionTensor3D<TOutput> operator()
+    ( const DiffusionTensor3D<TInput> & A )
+  {
+    DiffusionTensor3D<TOutput> tensor;
+    Matrix<double, 3, 3>       mat;
+    Matrix<double, 3, 3>       matcorrect;
+    typename DiffusionTensor3DExtended<double>::EigenValuesArrayType eigenValues;
+    typename DiffusionTensor3DExtended<double>::EigenVectorsMatrixType eigenVectors;
+    DiffusionTensor3DExtended<double> tensorDouble;
+    tensorDouble = ( DiffusionTensor3DExtended<TInput> )A;
+    tensorDouble.ComputeEigenAnalysis( eigenValues, eigenVectors );
+    for( int i = 0; i < 3; i++ )
+      {
+      mat[i][i] = ( eigenValues[i] < 0 ? -eigenValues[i] : eigenValues[i] );
+      }
+    eigenVectors = eigenVectors.GetTranspose();
+    matcorrect = eigenVectors * mat * eigenVectors.GetInverse();
+    tensorDouble.SetTensorFromMatrix( matcorrect );
+    for( int i = 0; i < 6; i++ )
+      {
+      tensor[i] = ( TOutput ) tensorDouble[i];
+      }
+    return tensor;
+  }
+
+};
+} // end of Functor namespace
+
+template <class TInputImage, class TOutputImage>
+class DiffusionTensor3DAbsCorrectionFilter :
+  public
+  UnaryFunctorImageFilter<TInputImage, TOutputImage,
+                          Functor::DiffusionTensor3DAbs<
+                            typename TInputImage::PixelType::ComponentType,
+                            typename TOutputImage::PixelType::ComponentType> >
+{
+public:
+  /** Standard class typedefs. */
+  typedef DiffusionTensor3DAbsCorrectionFilter Self;
+  typedef UnaryFunctorImageFilter<TInputImage, TOutputImage,
+                                  Functor::DiffusionTensor3DAbs<typename TInputImage::PixelType,
+                                                                typename TOutputImage::PixelType> >  Superclass;
+  typedef SmartPointer<Self>       Pointer;
+  typedef SmartPointer<const Self> ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro( Self );
+
+#ifdef ITK_USE_CONCEPT_CHECKING
+  /** Begin concept checking */
+  itkConceptMacro( InputTensorTypeCheck,
+                   ( Concept::SameType<DiffusionTensor3D<typename TInputImage::PixelType::ComponentType>,
+                                       typename TInputImage::PixelType> ) );
+  itkConceptMacro( OutputTensorTypeCheck,
+                   ( Concept::SameType<DiffusionTensor3D<typename TOutputImage::PixelType::ComponentType>,
+                                       typename TOutputImage::PixelType> ) );
+
+  /** End concept checking */
+#endif
+protected:
+  DiffusionTensor3DAbsCorrectionFilter()
+  {
+  }
+
+  virtual ~DiffusionTensor3DAbsCorrectionFilter()
+  {
+  }
+
+private:
+  DiffusionTensor3DAbsCorrectionFilter( const Self & ); // purposely not implemented
+  void operator=( const Self & );                       // purposely not implemented
+
+};
+
+} // end namespace itk
+
+#endif

--- a/Library/itkDiffusionTensor3DExtended.h
+++ b/Library/itkDiffusionTensor3DExtended.h
@@ -1,0 +1,62 @@
+/*=========================================================================
+
+  Program:   Diffusion Applications
+  Module:    $HeadURL: http://svn.slicer.org/Slicer3/trunk/Applications/CLI/DiffusionApplications/ResampleDTI/itkDiffusionTensor3DExtended.h $
+  Language:  C++
+  Date:      $Date: 2010-04-29 11:58:49 -0400 (Thu, 29 Apr 2010) $
+  Version:   $Revision: 13073 $
+
+  Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
+
+==========================================================================*/
+#ifndef __itkDiffusionTensor3DExtended_h
+#define __itkDiffusionTensor3DExtended_h
+
+#include <itkDiffusionTensor3D.h>
+#include <itkMatrix.h>
+
+namespace itk
+{
+
+/** \class DiffusionTensor3DExtended
+ *
+ * Implementation of a class that allows to transforms diffusion tensors
+ *  into symmetric-matrices (to compute transformed tensors) and transform back
+ * the matrices to tensors
+ */
+
+template <class T>
+class DiffusionTensor3DExtended : public DiffusionTensor3D<T>
+{
+public:
+  typedef T                           DataType;
+  typedef DiffusionTensor3DExtended   Self;
+  typedef DiffusionTensor3D<DataType> Superclass;
+  typedef Matrix<DataType, 3, 3>      MatrixType;
+  DiffusionTensor3DExtended()
+  {
+  }
+
+  DiffusionTensor3DExtended( const Superclass & tensor );
+  ///Get a Symmetric matrix representing the tensor
+  MatrixType GetTensor2Matrix();
+
+  ///Set the Tensor from a symmetric matrix
+  template <class C>
+  void SetTensorFromMatrix( Matrix<C, 3, 3> matrix );
+
+  ///Cast the component values of the tensor
+  template <class C>
+  operator DiffusionTensor3DExtended<C> const ();
+
+};
+
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkDiffusionTensor3DExtended.hxx"
+#endif
+
+#endif

--- a/Library/itkDiffusionTensor3DExtended.hxx
+++ b/Library/itkDiffusionTensor3DExtended.hxx
@@ -1,0 +1,78 @@
+/*=========================================================================
+
+  Program:   Diffusion Applications
+  Module:    $HeadURL: http://svn.slicer.org/Slicer3/trunk/Applications/CLI/DiffusionApplications/ResampleDTI/itkDiffusionTensor3DExtended.txx $
+  Language:  C++
+  Date:      $Date: 2010-04-29 11:58:49 -0400 (Thu, 29 Apr 2010) $
+  Version:   $Revision: 13073 $
+
+  Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
+
+==========================================================================*/
+#ifndef __itkDiffusionTensor3DExtended_hxx
+#define __itkDiffusionTensor3DExtended_hxx
+
+#include "itkDiffusionTensor3DExtended.h"
+
+namespace itk
+{
+
+template <class T>
+DiffusionTensor3DExtended<T>
+::DiffusionTensor3DExtended( const Superclass & tensor )
+{
+  for( int i = 0; i < 6; i++ )
+    {
+    this->SetElement( i, tensor.GetElement( i ) );
+    }
+}
+
+template <class T>
+typename DiffusionTensor3DExtended<T>::MatrixType
+DiffusionTensor3DExtended<T>
+::GetTensor2Matrix()
+{
+  MatrixType matrix;
+
+  for( int i = 0; i < 3; i++ )
+    {
+    for( int j = 0; j < 3; j++ )
+      {
+      matrix[i][j] = ( *this )( i, j );
+      }
+    }
+  return matrix;
+}
+
+template <class T>
+template <class C>
+void
+DiffusionTensor3DExtended<T>
+::SetTensorFromMatrix( Matrix<C, 3, 3> matrix )
+{
+  for( int i = 0; i < 3; i++ )
+    {
+    for( int j = i; j < 3; j++ )
+      {
+      ( *this )( i, j ) = static_cast<T>( matrix[i][j] );
+      }
+    }
+}
+
+template <class T>
+template <class C>
+DiffusionTensor3DExtended<T>
+::operator DiffusionTensor3DExtended<C> const ()
+  {
+  DiffusionTensor3DExtended<C> tmp;
+  for( int i = 0; i < 6; i++ )
+    {
+    tmp.SetElement( i, ( C ) ( this->GetElement( i ) ) );
+    }
+  return tmp;
+  }
+
+} // end namespace itk
+#endif

--- a/Library/itkDiffusionTensor3DNearestCorrection.h
+++ b/Library/itkDiffusionTensor3DNearestCorrection.h
@@ -1,0 +1,161 @@
+/*=========================================================================
+
+  Program:   Diffusion Applications
+  Module:    $HeadURL: http://svn.slicer.org/Slicer3/trunk/Applications/CLI/DiffusionApplications/ResampleDTI/itkDiffusionTensor3DNearestCorrection.h $
+  Language:  C++
+  Date:      $Date: 2010-04-29 11:58:49 -0400 (Thu, 29 Apr 2010) $
+  Version:   $Revision: 13073 $
+
+  Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
+
+==========================================================================*/
+#ifndef __itkDiffusionTensor3DNearestCorrectionFilter_h
+#define __itkDiffusionTensor3DNearestCorrectionFilter_h
+
+#include "itkUnaryFunctorImageFilter.h"
+#include "vnl/vnl_math.h"
+#include <itkMatrix.h>
+#include "itkDiffusionTensor3DExtended.h"
+
+namespace itk
+{
+
+/** \class DiffusionTensor3DNearestCorrectionFilter
+ *
+ * This filter is templated over the pixel type of the input image
+ * and the pixel type of the output image.
+ *
+ * The filter will walk over all the pixels in the input image, and for
+ * each one of them it will compute the nearest symmetric semi-definite matrix
+ * with the Frobenius norm.
+ *
+ *
+ * The filter expect both images to have the same dimension (e.g. both 2D,
+ * or both 3D, or both ND).
+ * The filter needs DiffusionTensor3D images to work
+ *
+ */
+namespace Functor
+{
+
+template <class TInput, class TOutput>
+class DiffusionTensor3DNearest
+{
+public:
+  DiffusionTensor3DNearest()
+  {
+  }
+
+  ~DiffusionTensor3DNearest()
+  {
+  }
+
+  bool operator!=( const DiffusionTensor3DNearest & other ) const
+  {
+    return *this != other;
+  }
+
+  bool operator==( const DiffusionTensor3DNearest & other ) const
+  {
+    return !( *this != other );
+  }
+
+  inline DiffusionTensor3D<TOutput> operator()
+    ( const DiffusionTensor3D<TInput> & tensorA )
+  {
+    DiffusionTensor3D<TOutput>        tensor;
+    DiffusionTensor3DExtended<double> tensorDouble;
+    tensorDouble = ( DiffusionTensor3DExtended<TInput> )tensorA;
+    Matrix<double, 3, 3> B;
+    Matrix<double, 3, 3> A;
+    Matrix<double, 3, 3> transpose;
+    Matrix<double, 3, 3> H;
+    Matrix<double, 3, 3> mat;
+    A = tensorDouble.GetTensor2Matrix();
+    transpose = A.GetTranspose();
+    B = (A + transpose) / 2;
+    transpose = B.GetTranspose();
+    H = transpose * B;
+    tensorDouble.SetTensorFromMatrix(H);
+
+    typename DiffusionTensor3DExtended<double>::EigenValuesArrayType eigenValues;
+    typename DiffusionTensor3DExtended<double>::EigenVectorsMatrixType eigenVectors;
+    tensorDouble.ComputeEigenAnalysis( eigenValues, eigenVectors );
+    for( int i = 0; i < 3; i++ )
+      {
+      mat[i][i] = sqrt(eigenValues[i]);
+      }
+    eigenVectors = eigenVectors.GetTranspose();
+    H = eigenVectors * mat * eigenVectors.GetInverse();
+    mat = (B + H) / 2;
+    tensorDouble.SetTensorFromMatrix( mat );
+    tensorDouble.ComputeEigenAnalysis( eigenValues, eigenVectors );  // sometimes very small negative eigenvalues
+                                                                     // appear; we suppress them
+    mat.Fill(0);
+    for( int i = 0; i < 3; i++ )
+      {
+      mat[i][i] = ( eigenValues[i] <= 0 ? ZERO : eigenValues[i] );
+      }
+    eigenVectors = eigenVectors.GetTranspose();
+    tensorDouble.SetTensorFromMatrix<double>( eigenVectors * mat * eigenVectors.GetInverse() );
+    for( int i = 0; i < 6; i++ )
+      {
+      tensor[i] = ( TOutput ) tensorDouble[i];
+      }
+    return tensor;
+  }
+
+};
+} // end of Functor namespace
+
+template <class TInputImage, class TOutputImage>
+class DiffusionTensor3DNearestCorrectionFilter :
+  public
+  UnaryFunctorImageFilter<TInputImage, TOutputImage,
+                          Functor::DiffusionTensor3DNearest<
+                            typename TInputImage::PixelType::ComponentType,
+                            typename TOutputImage::PixelType::ComponentType> >
+{
+public:
+  /** Standard class typedefs. */
+  typedef DiffusionTensor3DNearestCorrectionFilter Self;
+  typedef UnaryFunctorImageFilter<TInputImage, TOutputImage,
+                                  Functor::DiffusionTensor3DNearest<typename TInputImage::PixelType,
+                                                                    typename TOutputImage::PixelType> >  Superclass;
+  typedef SmartPointer<Self>       Pointer;
+  typedef SmartPointer<const Self> ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro( Self );
+
+#ifdef ITK_USE_CONCEPT_CHECKING
+  /** Begin concept checking */
+  itkConceptMacro( InputTensorTypeCheck,
+                   ( Concept::SameType<DiffusionTensor3D<typename TInputImage::PixelType::ComponentType>,
+                                       typename TInputImage::PixelType> ) );
+  itkConceptMacro( OutputTensorTypeCheck,
+                   ( Concept::SameType<DiffusionTensor3D<typename TOutputImage::PixelType::ComponentType>,
+                                       typename TOutputImage::PixelType> ) );
+
+  /** End concept checking */
+#endif
+protected:
+  DiffusionTensor3DNearestCorrectionFilter()
+  {
+  }
+
+  virtual ~DiffusionTensor3DNearestCorrectionFilter()
+  {
+  }
+
+private:
+  DiffusionTensor3DNearestCorrectionFilter( const Self & ); // purposely not implemented
+  void operator=( const Self & );                           // purposely not implemented
+
+};
+
+} // end namespace itk
+
+#endif

--- a/Library/itkDiffusionTensor3DZeroCorrection.h
+++ b/Library/itkDiffusionTensor3DZeroCorrection.h
@@ -1,0 +1,145 @@
+/*=========================================================================
+
+  Program:   Diffusion Applications
+  Module:    $HeadURL: http://svn.slicer.org/Slicer3/trunk/Applications/CLI/DiffusionApplications/ResampleDTI/itkDiffusionTensor3DZeroCorrection.h $
+  Language:  C++
+  Date:      $Date: 2010-03-15 18:00:34 -0400 (Mon, 15 Mar 2010) $
+  Version:   $Revision: 12353 $
+
+  Copyright (c) Brigham and Women's Hospital (BWH) All Rights Reserved.
+
+  See License.txt or http://www.slicer.org/copyright/copyright.txt for details.
+
+==========================================================================*/
+#ifndef __itkDiffusionTensor3DZeroCorrectionFilter_h
+#define __itkDiffusionTensor3DZeroCorrectionFilter_h
+
+#include "itkUnaryFunctorImageFilter.h"
+#include "vnl/vnl_math.h"
+#include <itkMatrix.h>
+#include "itkDiffusionTensor3DExtended.h"
+#include "define.h"
+
+namespace itk
+{
+
+/** \class DiffusionTensor3DZeroCorrectionFilter
+ *
+ * This filter is templated over the pixel type of the input image
+ * and the pixel type of the output image.
+ *
+ * The filter will walk over all the pixels in the input image, and for
+ * each one of them it will do the following:
+ *
+ * - cast the pixel value to \c DiffusionTensor3DExtended<double>,
+ * - Compute the eigenvalues and the eigenvectors
+ * - Set negative eigenvalues to zero
+ * - store the casted value into the output image.
+ *
+ * The filter expect both images to have the same dimension (e.g. both 2D,
+ * or both 3D, or both ND).
+ * The filter needs DiffusionTensor3D images to work
+ *
+ */
+namespace Functor
+{
+
+template <class TInput, class TOutput>
+class DiffusionTensor3DZero
+{
+public:
+  DiffusionTensor3DZero()
+  {
+  }
+
+  ~DiffusionTensor3DZero()
+  {
+  }
+
+  bool operator!=( const DiffusionTensor3DZero & other ) const
+  {
+    return *this != other;
+  }
+
+  bool operator==( const DiffusionTensor3DZero & other ) const
+  {
+    return !( *this != other );
+  }
+
+  inline DiffusionTensor3D<TOutput> operator()
+    ( const DiffusionTensor3D<TInput> & A )
+  {
+    DiffusionTensor3D<TOutput> tensor;
+    Matrix<double, 3, 3>       mat;
+    Matrix<double, 3, 3>       matcorrect;
+    typename DiffusionTensor3DExtended<double>::EigenValuesArrayType eigenValues;
+    typename DiffusionTensor3DExtended<double>::EigenVectorsMatrixType eigenVectors;
+    DiffusionTensor3DExtended<double> tensorDouble;
+    tensorDouble = ( DiffusionTensor3DExtended<TInput> )A;
+    tensorDouble.ComputeEigenAnalysis( eigenValues, eigenVectors );
+    for( int i = 0; i < 3; i++ )
+      {
+      mat[i][i] = ( eigenValues[i] <= 0 ? ZERO : eigenValues[i] );
+      }
+    eigenVectors = eigenVectors.GetTranspose();
+    matcorrect = eigenVectors * mat * eigenVectors.GetInverse();
+    tensorDouble.SetTensorFromMatrix( matcorrect );
+    for( int i = 0; i < 6; i++ )
+      {
+      tensor[i] = ( TOutput ) tensorDouble[i];
+      }
+    return tensor;
+  }
+
+};
+} // end of Functor namespace
+
+template <class TInputImage, class TOutputImage>
+class DiffusionTensor3DZeroCorrectionFilter :
+  public
+  UnaryFunctorImageFilter<TInputImage, TOutputImage,
+                          Functor::DiffusionTensor3DZero<
+                            typename TInputImage::PixelType::ComponentType,
+                            typename TOutputImage::PixelType::ComponentType> >
+{
+public:
+  /** Standard class typedefs. */
+  typedef DiffusionTensor3DZeroCorrectionFilter Self;
+  typedef UnaryFunctorImageFilter<TInputImage, TOutputImage,
+                                  Functor::DiffusionTensor3DZero<typename TInputImage::PixelType,
+                                                                 typename TOutputImage::PixelType> >  Superclass;
+  typedef SmartPointer<Self>       Pointer;
+  typedef SmartPointer<const Self> ConstPointer;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro( Self );
+
+#ifdef ITK_USE_CONCEPT_CHECKING
+  /** Begin concept checking */
+  itkConceptMacro( InputTensorTypeCheck,
+                   ( Concept::SameType<DiffusionTensor3D<typename TInputImage::PixelType::ComponentType>,
+                                       typename TInputImage::PixelType> ) );
+  itkConceptMacro( OutputTensorTypeCheck,
+                   ( Concept::SameType<DiffusionTensor3D<typename TOutputImage::PixelType::ComponentType>,
+                                       typename TOutputImage::PixelType> ) );
+
+  /** End concept checking */
+#endif
+protected:
+  DiffusionTensor3DZeroCorrectionFilter()
+  {
+  }
+
+  virtual ~DiffusionTensor3DZeroCorrectionFilter()
+  {
+  }
+
+private:
+  DiffusionTensor3DZeroCorrectionFilter( const Self & ); // purposely not implemented
+  void operator=( const Self & );                        // purposely not implemented
+
+};
+
+} // end namespace itk
+
+#endif

--- a/Library/itkFastSymmetricEigenAnalysisImageFilter.h
+++ b/Library/itkFastSymmetricEigenAnalysisImageFilter.h
@@ -14,8 +14,8 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#ifndef __itkSymmetricEigenAnalysisImageFilter_h
-#define __itkSymmetricEigenAnalysisImageFilter_h
+#ifndef __itkFastSymmetricEigenAnalysisImageFilter_h
+#define __itkFastSymmetricEigenAnalysisImageFilter_h
 
 #include <itkUnaryFunctorImageFilter.h>
 #include <vnl/algo/vnl_symmetric_eigensystem.h>
@@ -28,9 +28,6 @@ namespace itk
 // operator, while the output pixel type must provide the API for the
 // [] operator. Input pixel matrices should be symmetric.
 //
-// The default operation is to order eigen values in ascending order.
-// You may also use OrderEigenValuesBy( ) to order eigen values by
-// magnitude as is common with use of tensors in vessel extraction.
 namespace Functor
 {
 
@@ -69,45 +66,17 @@ public:
                                                 lambdas[2]);
     return TOutput(lambdas);
   }
-
-  /** Typdedefs to order eigen values.
-   * OrderByValue:      lambda_1 < lambda_2 < ....
-   * OrderByMagnitude:  |lambda_1| < |lambda_2| < .....
-   * DoNotOrder:        Default order of eigen values obtained after QL method
-   */
-  typedef enum
-    {
-    OrderByValue = 1,
-    OrderByMagnitude,
-    DoNotOrder
-    } EigenValueOrderType;
-
-  /** Order eigen values. Default is to OrderByValue:  lambda_1 <
-   * lambda_2 < .... */
-  void OrderEigenValuesBy( EigenValueOrderType order )
-  {
-    m_Order = order;
-  }
-
-private:
-  EigenValueOrderType m_Order;
 };
 
 }  // end namespace functor
 
-/** \class SymmetricEigenAnalysisImageFilter
+/** \class FastSymmetricEigenAnalysisImageFilter
  * \brief Computes the Fractional Anisotropy for every pixel of a input tensor image.
  *
- * SymmetricEigenAnalysisImageFilter applies pixel-wise the invokation for
+ * FastSymmetricEigenAnalysisImageFilter applies pixel-wise the invokation for
  * computing the fractional anisotropy of every pixel. The pixel type of the
  * input image is expected to implement a method GetFractionalAnisotropy(), and
  * to specify its return type as  RealValueType.
- *
- * The OrderEigenValuesBy( .. ) method can be used to order eigen values
- * in ascending order by value or magnitude or no ordering.
- * OrderByValue:      lambda_1 < lambda_2 < ....
- * OrderByMagnitude:  |lambda_1| < |lambda_2| < .....
- * DoNotOrder:        Default order of eigen values obtained after QL method
  *
  * The user of this class is explicitly supposed to set the dimension of the
  * 2D matrix using the SetDimension() method.
@@ -142,20 +111,6 @@ public:
   typedef typename TInputImage::PixelType      InputPixelType;
   typedef typename InputPixelType::ValueType   InputValueType;
   typedef typename Superclass::FunctorType     FunctorType;
-
-  /** Typdedefs to order eigen values.
-   * OrderByValue:      lambda_1 < lambda_2 < ....
-   * OrderByMagnitude:  |lambda_1| < |lambda_2| < .....
-   * DoNotOrder:        Default order of eigen values obtained after QL method
-   */
-  typedef typename FunctorType::EigenValueOrderType EigenValueOrderType;
-
-  /** Order eigen values. Default is to OrderByValue:  lambda_1 <
-   * lambda_2 < .... */
-  void OrderEigenValuesBy( EigenValueOrderType order )
-  {
-    this->GetFunctor().OrderEigenValuesBy( order );
-  }
 
   /** Run-time type information (and related methods).   */
   itkTypeMacro( FastSymmetricEigenAnalysisImageFilter, UnaryFunctorImageFilter );

--- a/PrivateLibrary/tensorscalars.cxx
+++ b/PrivateLibrary/tensorscalars.cxx
@@ -92,7 +92,6 @@ itk::Image<double, 3>::Pointer createLambda<double>(TensorImageType::Pointer tim
   typedef itk::FastSymmetricEigenAnalysisImageFilter<TensorImageType, DeformationImageType> LambdaFilterType;
   LambdaFilterType::Pointer lambdafilter = LambdaFilterType::New();
   lambdafilter->SetInput(timg);
-  lambdafilter->OrderEigenValuesBy(LambdaFilterType::FunctorType::OrderByValue);
   lambdafilter->Update();
 
   typedef itk::VectorIndexSelectionCastImageFilter<LambdaFilterType::OutputImageType,
@@ -130,7 +129,6 @@ itk::Image<double, 3>::Pointer createRD<double>(TensorImageType::Pointer timg) /
   typedef itk::FastSymmetricEigenAnalysisImageFilter<TensorImageType, DeformationImageType> LambdaFilterType;
   LambdaFilterType::Pointer lambdafilter = LambdaFilterType::New();
   lambdafilter->SetInput(timg);
-  lambdafilter->OrderEigenValuesBy(LambdaFilterType::FunctorType::OrderByValue);
   lambdafilter->Update();
 
   typedef itk::AddImageFilter<RealImageType, RealImageType, RealImageType> RDFilterType;


### PR DESCRIPTION
The following patches add a new option named "--correction" to dtiprocess and dtiestim.
This option corrects the tensors if computed tensor is not semi-definite positive.
    
--correction <zero|none|abs|nearest>
(default: none)
    
This option keeps the tensor correction consistent between ResampleDTIlogEuclidean, dtiprocess and dtiestim.