### PR TITLE
BUG: Fix loading of CLI modules when built as an extension.

### DIFF
--- a/Applications/CMakeLists.txt
+++ b/Applications/CMakeLists.txt
@@ -22,6 +22,25 @@ ADD_EXECUTABLE(morph morph.cxx)
 TARGET_LINK_LIBRARIES(morph ${DTIProcess_ITK_LIBRARIES})
 export(TARGETS morph APPEND FILE ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}-exports.cmake)
 
+# When built as a Slicer extension, this will ensure that the CLI executables
+# can resolve the path of the ITK/VTK/... libraries provided by Slicer.
+#
+# It is usually done in UseSlicer.cmake included after calling
+# find_package(Slicer)/include(${Slicer_USE_FILE}). But since in this project
+# these calls are only done in SuperBuild.cmake, we explicily set the executable
+# and library link flags here.
+#
+# Note: These flags are currently used independently of the value of
+#       DTIProcess_BUILD_SLICER_EXTENSION. If this is a problem, the approach
+#       should be revisited so that the parameter DTIProcess_BUILD_SLICER_EXTENSION
+#       is propagated from the top-level down to this project.
+if(APPLE)
+  set(SlicerExecutionModel_DEFAULT_CLI_EXECUTABLE_LINK_FLAGS
+    "${SlicerExecutionModel_DEFAULT_CLI_EXECUTABLE_LINK_FLAGS} -Wl,-rpath,@loader_path/../../../../../")
+  set(SlicerExecutionModel_DEFAULT_CLI_LIBRARY_LINK_FLAGS
+    "${SlicerExecutionModel_DEFAULT_CLI_LIBRARY_LINK_FLAGS} -Wl,-rpath,@loader_path/../../../../../")
+endif()
+
 macro(SEM_BUILD_EXECUTABLE)
   set(options )
   set( oneValueArgs NAME )


### PR DESCRIPTION
This commit partially fixes issue #14. It only addresses the loading
of CLI executables built in the Applications folder. The CLI
build in the "niral_utilities" project [1] would have to be updated
to either

 (1) use the macro "SEMMacroBuildCLI" so that configuring the
"niral_utilities" project with SlicerExecutionModel_DEFAULT_CLI_(EXECUTABLE|LIBRARY)_LINK_FLAGS
is effective

or

 (2) explicitly set the linker flags on the executable.

Approach (1) is definitively recommended.