### PR TITLE
ENH: Update niral utilities version

### DIFF
--- a/SuperBuild/External_niral_utilities.cmake
+++ b/SuperBuild/External_niral_utilities.cmake
@@ -73,7 +73,7 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
 
   ### --- End Project specific additions
   set( ${proj}_REPOSITORY ${git_protocol}://github.com/NIRALUser/niral_utilities.git )
-  set( ${proj}_GIT_TAG 50711ce510bc03f3aa77e2730d48741f6a83732a )
+  set( ${proj}_GIT_TAG 8f1290d823547ebb7be75db9cc552b7a1594f82a )
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}
     GIT_TAG ${${proj}_GIT_TAG}


### PR DESCRIPTION
This version fixes issues with the executables polydatatransform and polydatamerge. They were beign generated with a shared library. Now they are generated statically