### PR TITLE
BUG: During DTIPrep superbuild

### DIFF
--- a/DTIProcess.cmake
+++ b/DTIProcess.cmake
@@ -99,6 +99,7 @@ if(NOT VTK_FOUND)
     find_package(VTK COMPONENTS
       vtkIOLegacy
       vtkIOXML
+      vtkCommonDataModel
       REQUIRED)
     include(${VTK_USE_FILE})
 endif(NOT VTK_FOUND)


### PR DESCRIPTION
The module vtkCommonDataModel needs to be discovered otherwise there are linking errors for fiberprocess executable