### PR TITLE
BUG: Remove if condition, always find VTK package

### DIFF
--- a/DTIProcess.cmake
+++ b/DTIProcess.cmake
@@ -95,14 +95,14 @@ set(DTIProcess_ITK_LIBRARIES ${ITK_LIBRARIES})
 
 
 
-if(NOT VTK_FOUND)
-    find_package(VTK COMPONENTS
-      vtkIOLegacy
-      vtkIOXML
-      vtkCommonDataModel
-      REQUIRED)
-    include(${VTK_USE_FILE})
-endif(NOT VTK_FOUND)
+
+find_package(VTK COMPONENTS
+  vtkIOLegacy
+  vtkIOXML
+  vtkCommonDataModel
+  REQUIRED)
+include(${VTK_USE_FILE})
+
 
 
 INCLUDE_DIRECTORIES(


### PR DESCRIPTION
During superbuild, the VTK components might differ from the ones needed by DTIProcess. If the variable VTK_FOUND is set the component vtkCommonDataModel won't be found