### PR TITLE
COMP: Improve C++11 building

### DIFF
--- a/Common.cmake
+++ b/Common.cmake
@@ -43,7 +43,7 @@ endif()
 #-----------------------------------------------------------------------------
 # Enable and setup External project global properties
 #-----------------------------------------------------------------------------
-include(ExternalProject) 
+include(ExternalProject)
 include(SlicerMacroEmptyExternalProject)
 include(SlicerMacroCheckExternalProjectDependency)
 
@@ -211,6 +211,7 @@ list(APPEND ${CMAKE_PROJECT_NAME}_SUPERBUILD_EP_VARS
   CMAKE_C_FLAGS_RELEASE:STRING
   CMAKE_C_FLAGS_DEBUG:STRING
   CMAKE_C_FLAGS:STRING
+  CMAKE_CXX_STANDARD:STRING
   CMAKE_SHARED_LINKER_FLAGS:STRING
   CMAKE_EXE_LINKER_FLAGS:STRING
   CMAKE_MODULE_LINKER_FLAGS:STRING


### PR DESCRIPTION
When building for C++11 with CMake, we need to propagate the CMAKE_CXX_STANDARD
setting to superbuild sub-projects consistently.