### PR TITLE
Fix build error on Windows

### DIFF
--- a/Library/itkDiffusionTensor3DReconstructionImageFilterBase.txx
+++ b/Library/itkDiffusionTensor3DReconstructionImageFilterBase.txx
@@ -26,14 +26,6 @@
 #include "itkArray.h"
 #include "vnl/vnl_vector.h"
 
-
-#ifdef WIN32
-long round(double a) // round not defined on windows // no positive/negative statement because always called for exp()>0 (see l.156)
-{
-  return ((a-(long)a)>=0.5)?(long)a+1:(long)a;
-}
-#endif
-
 namespace itk
 {
 


### PR DESCRIPTION
VS2013 has round() function and if you redefine it causes build error (see http://slicer.cdash.org/viewBuildError.php?buildid=1021062).

If you need backward compatibility with older VS versions then you can add a try_compile test for round().